### PR TITLE
Removing import of builtins library

### DIFF
--- a/install.py
+++ b/install.py
@@ -13,7 +13,6 @@
 
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from builtins import *
 
 import os
 import sys


### PR DESCRIPTION
I don't believe this is necessary. It was making my installation fail, I removed the line and the modules installed successfully.