### PR TITLE
Make the module usable with virtualenv

### DIFF
--- a/install.py
+++ b/install.py
@@ -20,7 +20,7 @@ import sys
 import logging
 import logging.config
 
-log_root = '/var/log'
+log_root = '.'
 dell_emc_log_path = log_root + '/dellemc'
 
 # create log directory in the log root var/log
@@ -85,7 +85,6 @@ module_utils_path = ansible_path + '/module_utils/'
 extras_path = ansible_path + '/modules/extras'
 server_path = extras_path + '/dellemc'
 dellemc_idrac_path = server_path + '/server'
-log_root = '/var/log'
 dell_emc_log_path = log_root + '/dellemc'
 
 warning_message = "Dell EMC OpenManage Ansible Module 1.0 is already present. Do you want to overwrite? (y/n)  "

--- a/uninstall.py
+++ b/uninstall.py
@@ -17,7 +17,7 @@ import sys
 import logging.config
 import shutil
 try:
-    log_root = '/var/log'
+    log_root = '.'
     dell_emc_log_path = log_root + '/dellemc'
     dell_emc_log_file = dell_emc_log_path + '/dellemc_log.conf'
     logging.config.fileConfig(dell_emc_log_file, defaults={'logfilename': dell_emc_log_path + '/dellemc_ansible_uninstall.log'})

--- a/uninstall.py
+++ b/uninstall.py
@@ -22,7 +22,7 @@ try:
     dell_emc_log_file = dell_emc_log_path + '/dellemc_log.conf'
     logging.config.fileConfig(dell_emc_log_file, defaults={'logfilename': dell_emc_log_path + '/dellemc_ansible_uninstall.log'})
 except Exception as e:
-    print('Dell EMC OpenManage Ansible Modules v1.0 is not installed.')
+    print('Unable to access the uninstallation logfile')
     sys.exit(1)
 
 # create logger


### PR DESCRIPTION
By changing the log folder from /var/log/dellemc to ./dellemc (subdirectory  in current directory), you don't need root-rights anymore for the installation. This enables the module to be installed inside a virtualenv, the global installation as before is still possible.
Also changed the error message in the uninstallation. When you can't access the logfile, this doesn't mean the module isn't installed.